### PR TITLE
Fixing installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requirements = [
 
 setup(
     name = 'yql',
-    packages = ['yql'],
+    packages = ['yql', 'yql.api'],
     version = '1.0.0',
     long_description= readme(),
     description = "python interface for yql",


### PR DESCRIPTION
Hello,

I tried to install yql using pip, it was installed ok and when I tried to use I was receiving this error:

``` python
In [1]: import yql
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-1-bfb41110a347> in <module>()
----> 1 import yql

build/bdist.macosx-10.10-intel/egg/yql/__init__.py in <module>()

ImportError: No module named api._api_request
```

Looking at the source files that was installed into my virtualenv I realised that the internal api package was not there.

Adding `"yql.api"` to packages list into the setup.py fixed the issue.
